### PR TITLE
bring oqsprovider code points in line with IANA and this branch

### DIFF
--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -73,4 +73,12 @@ export OPENSSL_CONF=$OQS_PROVIDER_TESTSCRIPTS/openssl-ca.cnf
 # Be verbose if harness is verbose:
 # Fixup for oqsprovider release snafu:
 cp $SRCTOP/test/recipes/95-test_external_oqsprovider_data/oqsprovider-pkcs12gen.sh $SRCTOP/oqs-provider/scripts/
+# These ensure Frodo doesn't fail because of a wrong code point assignment:
+export OQS_CODEPOINT_FRODO640AES=65024
+export OQS_CODEPOINT_FRODO640SHAKE=65025
+export OQS_CODEPOINT_FRODO976AES=65026
+# These ensure oqsprovider uses ML-KEM at the right code points
+export OQS_CODEPOINT_MLKEM512=512
+export OQS_CODEPOINT_MLKEM768=513
+export OQS_CODEPOINT_MLKEM1024=514
 $SRCTOP/oqs-provider/scripts/runtests.sh -V


### PR DESCRIPTION
@vdukhovni These changes serve to enable oqsprovider testing with correct code points. This testing may highlight a problem with the ML-KEM provider in https://github.com/openssl/openssl/pull/26172. For reference, here's the test causing problems: https://github.com/open-quantum-safe/oqs-provider/blob/f7228d214febb3f6848dfe80a464a2c7379f2edf/test/oqs_test_groups.c#L45-L77: At least I don't see a glaring problem why this test passes with `oqsprovider` and not with the new ML-KEM provider.